### PR TITLE
I fixed the Xcode build errors caused by duplicate compilation of Cor…

### DIFF
--- a/NutriJournal.xcodeproj/project.pbxproj
+++ b/NutriJournal.xcodeproj/project.pbxproj
@@ -7,10 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		40A80D5F2DEBB61200DB249A /* MealEntry+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A80D5E2DEBB61200DB249A /* MealEntry+CoreDataProperties.swift */; };
-		40A80D602DEBB61200DB249A /* MealDetail+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A80D5C2DEBB61200DB249A /* MealDetail+CoreDataProperties.swift */; };
-		40A80D612DEBB61200DB249A /* MealDetail+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A80D5B2DEBB61200DB249A /* MealDetail+CoreDataClass.swift */; };
-		40A80D622DEBB61200DB249A /* MealEntry+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A80D5D2DEBB61200DB249A /* MealEntry+CoreDataClass.swift */; };
 		40A80D6E2DEBBD7500DB249A /* CalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A80D5A2DEBB28B00DB249A /* CalendarView.swift */; };
 		40A80D6F2DEBBE3C00DB249A /* DailyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A80D6A2DEBB73600DB249A /* DailyView.swift */; };
 		40A80D702DEBBE4900DB249A /* SummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A80D6D2DEBB7D000DB249A /* SummaryView.swift */; };
@@ -209,14 +205,10 @@
 				40A80D6E2DEBBD7500DB249A /* CalendarView.swift in Sources */,
 				40A80D6F2DEBBE3C00DB249A /* DailyView.swift in Sources */,
 				40A80D712DEBBE5B00DB249A /* MealEntryEditView.swift in Sources */,
-				40A80D5F2DEBB61200DB249A /* MealEntry+CoreDataProperties.swift in Sources */,
 				40A80D702DEBBE4900DB249A /* SummaryView.swift in Sources */,
-				40A80D602DEBB61200DB249A /* MealDetail+CoreDataProperties.swift in Sources */,
 				40A80D722DEBC25F00DB249A /* MealType.swift in Sources */,
 				40A80D742DEBC27100DB249A /* Date+Extensions.swift in Sources */,
 				40A80D752DEBC35D00DB249A /* PersistenceController.swift in Sources */,
-				40A80D612DEBB61200DB249A /* MealDetail+CoreDataClass.swift in Sources */,
-				40A80D622DEBB61200DB249A /* MealEntry+CoreDataClass.swift in Sources */,
 				40A80D732DEBC26C00DB249A /* MacroCalculator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
…e Data files.

Your project was encountering "Multiple commands produce..." errors during the Xcode build process. This was primarily due to Core Data generated files (MealEntry+CoreDataClass.swift, MealEntry+CoreDataProperties.swift, MealDetail+CoreDataClass.swift, MealDetail+CoreDataProperties.swift) being included explicitly in the compile sources build phase.

Xcode automatically handles the compilation of these files as part of processing the .xcdatamodeld. Including them manually in the build phase leads to them being processed twice, causing the observed errors.

I resolved the issue by removing these four Core Data generated files from the PBXSourcesBuildPhase and their corresponding PBXBuildFile entries in the project.pbxproj file.

I also noted the Info.plist "multiple commands" error. I didn't make any direct changes for Info.plist at this time, as the primary Core Data fix might resolve it, or it may require separate investigation if it persists. Your project already uses the standard `GENERATE_INFOPLIST_FILE = YES` setting.